### PR TITLE
Add a method to clear the document cache

### DIFF
--- a/src/main/java/ninja/egg82/utils/DocumentUtil.java
+++ b/src/main/java/ninja/egg82/utils/DocumentUtil.java
@@ -64,4 +64,8 @@ public class DocumentUtil {
             throw new IOException("Could not convert URL to URI.", ex);
         }
     }
+    
+    pubic static synchronized void clearDocumentCache() {
+        documentCache.clear();
+    }
 }

--- a/src/main/java/ninja/egg82/utils/DocumentUtil.java
+++ b/src/main/java/ninja/egg82/utils/DocumentUtil.java
@@ -65,7 +65,7 @@ public class DocumentUtil {
         }
     }
     
-    pubic static synchronized void clearDocumentCache() {
+    public static synchronized void clearDocumentCache() {
         documentCache.clear();
     }
 }


### PR DESCRIPTION
DocumentUtil keeps a bunch of stuff in memory long after it's no longer needed again.

This PR adds a method to clear that so that it's possible to clear those after runtime dependencies have been downloaded.